### PR TITLE
SIM commands no longer stripped of semicolons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 jdk:
     - openjdk7
-    - openjdk8
+    - oraclejdk8
 
 sudo: false
 
@@ -15,4 +15,4 @@ before_script:
 script:
     - ant
     - ant
-    - ./sim_native_tests.sh
+    - dist/bin/jython nativeSIMunitTests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 jdk:
     - openjdk7
-    - oraclejdk8
 
 sudo: false
 
@@ -14,7 +13,6 @@ before_script:
 
 script:
     - pwd
-    - ant
     - ant
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+
+jdk:
+    - openjdk7
+    - openjdk8
+
+sudo: false
+
+before_script:
+    - cd jyhton
+    - uname -a
+    - printenv
+
+script:
+    - ant
+    - ant
+    - ./sim_native_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ before_script:
     - printenv
 
 script:
+    - pwd
     - ant
     - ant
+
+after_success:
+    - jdk_switcher use oraclejdk8
+
+after_script:
     - dist/bin/jython nativeSIMunitTests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 
 before_script:
     - cd jyhton
+    - export INSTALLATION_ROOT="."
     - uname -a
     - printenv
 

--- a/jyhton/Neo4j/WDB-new/src/database/wdb/WDB.java
+++ b/jyhton/Neo4j/WDB-new/src/database/wdb/WDB.java
@@ -47,7 +47,7 @@ public class WDB {
 			db = new SleepyCatDataBase(dbDir.toString());
 			db.openDb("test");
 			
-			System.out.println("WDB Simantic OracleNoSQLDatabase Project");
+			System.out.println("WDB Simantic Database Project");
 			System.out.println("Copyright 2006 University of Texas at Austin");
 			System.out.println("DB Name: " + db.dbName + " DB Path: " + db.fileName);
 			

--- a/jyhton/Neo4j/WDB/src/database/wdb/WDB.java
+++ b/jyhton/Neo4j/WDB/src/database/wdb/WDB.java
@@ -47,7 +47,7 @@ public class WDB {
 			db = new SleepyCatDataBase(dbDir.toString());
 			db.openDb("test");
 			
-			System.out.println("WDB Simantic OracleNoSQLDatabase Project");
+			System.out.println("WDB Simantic Database Project");
 			System.out.println("Copyright 2006 University of Texas at Austin");
 			System.out.println("DB Name: " + db.dbName + " DB Path: " + db.fileName);
 			

--- a/jyhton/build.xml
+++ b/jyhton/build.xml
@@ -209,7 +209,6 @@ oracle.jar=C:/workspace/HEAD/for_development/bisdevsrv28/jboss/server/infra/lib/
             <pathelement path="${extlibs.dir}/slf4j-log4j12-1.6.4.jar"/>
             <pathelement path="${extlibs.dir}/sqljdbc4.jar"/>
             <pathelement path="${extlibs.dir}/stringtemplate-3.2.1.jar"/>
-            <!-- <pathelement path="${extlibs.dir}/wdb.jar"/> -->
             <pathelement path="${extlibs.dir}/wdb-newest.jar"/>
             <pathelement path="${extlibs.dir}/xercesImpl-2.10.0.jar"/>
             <pathelement path="${extlibs.dir}/xml-apis-1.4.01.jar"/>
@@ -724,7 +723,7 @@ The readme text for the next release will be like:
             <zipfileset src="${extlibs.dir}/slf4j-log4j12-1.6.4.jar"/>
             <zipfileset src="${extlibs.dir}/sqljdbc4.jar"/>
             <zipfileset src="${extlibs.dir}/stringtemplate-3.2.1.jar"/>
-            <!-- <zipfileset src="${extlibs.dir}/wdb.jar"/> -->
+            <zipfileset src="${extlibs.dir}/wdb-newest.jar"/>
             <zipfileset src="${extlibs.dir}/xercesImpl-2.10.0.jar"/>
             <zipfileset src="${extlibs.dir}/xml-apis-1.4.01.jar"/>
             <zipfileset src="${extlibs.dir}/batches.jar" />

--- a/jyhton/grammar/Python.g
+++ b/jyhton/grammar/Python.g
@@ -1912,7 +1912,7 @@ sim_stmt
         {
             conn_name = actions.makeNameNode($name);
         } (s += STRING (e = expr[expr_contextType.Load])?
-               { strings.add(actions.extractStrings($s, encoding, unicodeLiterals).toString().replaceAll(";", "")); $s = null;
+               { strings.add(actions.extractStrings($s, encoding, unicodeLiterals).toString().replaceAll(";", "_^_")); $s = null;
                  if(e != null) exprs.add(actions.castExpr($e.tree)); e = null;
                }
           )+

--- a/jyhton/nativeSIMunitTests.py
+++ b/jyhton/nativeSIMunitTests.py
@@ -5,72 +5,72 @@ connOracleNoSQL = connectTo 'OracleNoSQL' 'C##cs329e_UTEid' 'orcl_UTEid' 'native
 print "Connections are opened, start loading Databases"
 
 # sim_person
-SIM on connOracleNoSQL 'CLASS sim_person ( PERSON_ID:INTEGER, REQUIRED ! NAME :STRING ! SSNUM :INTEGER ! GENDER :STRING ! BIRTH_DATE :STRING ! ADDRESS :STRING ! CITY :STRING ! STATE :STRING ! ZIP :INTEGER ! )!'
+SIM on connOracleNoSQL 'CLASS sim_person ( PERSON_ID:INTEGER, REQUIRED ; NAME :STRING ; SSNUM :INTEGER ; GENDER :STRING ; BIRTH_DATE :STRING ; ADDRESS :STRING ; CITY :STRING ; STATE :STRING ; ZIP :INTEGER ; );'
 
 # sim_emp--->sim_person
-SIM on connOracleNoSQL 'SUBCLASS sim_emp OF sim_person ( EMP_ID:INTEGER, REQUIRED ! HIRE_DATE :STRING ! SALARY :INTEGER ! STATUS :STRING ! )!'
+SIM on connOracleNoSQL 'SUBCLASS sim_emp OF sim_person ( EMP_ID:INTEGER, REQUIRED ; HIRE_DATE :STRING ; SALARY :INTEGER ; STATUS :STRING ; );'
 
 # sim_project_emp--->sim_emp--->sim_person
-SIM on connOracleNoSQL 'SUBCLASS sim_project_emp OF sim_emp ( TITLE :STRING ! RATING :STRING ! projects :sim_project, MV(DISTINCT), INVERSE IS employees ! department :sim_dept, INVERSE IS employees ! )!'
+SIM on connOracleNoSQL 'SUBCLASS sim_project_emp OF sim_emp ( TITLE :STRING ; RATING :STRING ; projects :sim_project, MV(DISTINCT), INVERSE IS employees ; department :sim_dept, INVERSE IS employees ; );'
 
 # sim_manager--->sim_emp--->sim_person
-SIM on connOracleNoSQL 'SUBCLASS sim_manager OF sim_emp ( TITLE :STRING ! BONUS :INTEGER ! department :sim_dept, INVERSE IS manager ! )!'
+SIM on connOracleNoSQL 'SUBCLASS sim_manager OF sim_emp ( TITLE :STRING ; BONUS :INTEGER ; department :sim_dept, INVERSE IS manager ; );'
 
 # sim_dept
 # RELATIONSHIPS: sim_dept 1-1 sim_manager,  sim_dept 1-M sim_project_emp,   sim_dept 1-M sim_project
-SIM on connOracleNoSQL 'CLASS sim_dept ( DEPT_ID:INTEGER, REQUIRED ! NAME :STRING ! LOCATION :STRING ! employees :sim_project_emp, MV(DISTINCT), INVERSE IS department ! projects :sim_project, MV(DISTINCT), INVERSE IS department ! manager :sim_manager, INVERSE IS department ! )!'
+SIM on connOracleNoSQL 'CLASS sim_dept ( DEPT_ID:INTEGER, REQUIRED ; NAME :STRING ; LOCATION :STRING ; employees :sim_project_emp, MV(DISTINCT), INVERSE IS department ; projects :sim_project, MV(DISTINCT), INVERSE IS department ; manager :sim_manager, INVERSE IS department ; );'
 
 # sim_project
-SIM on connOracleNoSQL 'CLASS sim_project ( PROJECT_ID:INTEGER, REQUIRED ! NAME :STRING ! employees :sim_project_emp, MV(DISTINCT), INVERSE IS projects ! department :sim_dept, INVERSE IS projects ! )!'
+SIM on connOracleNoSQL 'CLASS sim_project ( PROJECT_ID:INTEGER, REQUIRED ; NAME :STRING ; employees :sim_project_emp, MV(DISTINCT), INVERSE IS projects ; department :sim_dept, INVERSE IS projects ; );'
 
 # 6 instances of sim_project_emp
-SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 13 , NAME := "AARON" , SSNUM := 100 , GENDER := "MALE" , BIRTH_DATE := "01/01/87" , ADDRESS := "123 NOTHING LN" , CITY := "NEW YORK" , STATE := "NEW YORK" , ZIP := 888 , EMP_ID := 100100 , HIRE_DATE := "01/01/07" , SALARY := 87000 , STATUS := "EMPLOYED" , TITLE := "MARKETER"  , RATING := "OKAY")! '
-SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 2 , NAME := "ILYA" , SSNUM := 200 , GENDER := "MALE" , BIRTH_DATE := "01/02/87" , ADDRESS := "123 NOTHING LN" , CITY := "NEW YORK" , STATE := "NEW YORK" , ZIP := 888 , EMP_ID := 200200 , HIRE_DATE := "01/02/07" , SALARY := 67000 , STATUS := "EMPLOYED" , TITLE := "MARKETER"  , RATING := "SUCKY")! '
-SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 3 , NAME := "TY" , SSNUM := 300 , GENDER := "FEMALE" , BIRTH_DATE := "01/03/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 300300 , HIRE_DATE := "01/03/07" , SALARY := 92000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "AWESOME")! '
-SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 4 , NAME := "PETER" , SSNUM := 400 , GENDER := "FEMALE" , BIRTH_DATE := "01/04/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 400400 , HIRE_DATE := "01/04/07" , SALARY := 112000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "AVERAGE")! '
-SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 5 , NAME := "DERP" , SSNUM := 500 , GENDER := "MALE" , BIRTH_DATE := "01/05/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 500500 , HIRE_DATE := "01/05/07" , SALARY := 85000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "EXCEPTIONAL")! '
-SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 6 , NAME := "BOB" , SSNUM := 600 , GENDER := "MALE" , BIRTH_DATE := "01/06/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 600600 , HIRE_DATE := "01/06/07" , SALARY := 187000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "SAVANT")! '
+SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 13 , NAME := "AARON" , SSNUM := 100 , GENDER := "MALE" , BIRTH_DATE := "01/01/87" , ADDRESS := "123 NOTHING LN" , CITY := "NEW YORK" , STATE := "NEW YORK" , ZIP := 888 , EMP_ID := 100100 , HIRE_DATE := "01/01/07" , SALARY := 87000 , STATUS := "EMPLOYED" , TITLE := "MARKETER"  , RATING := "OKAY"); '
+SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 2 , NAME := "ILYA" , SSNUM := 200 , GENDER := "MALE" , BIRTH_DATE := "01/02/87" , ADDRESS := "123 NOTHING LN" , CITY := "NEW YORK" , STATE := "NEW YORK" , ZIP := 888 , EMP_ID := 200200 , HIRE_DATE := "01/02/07" , SALARY := 67000 , STATUS := "EMPLOYED" , TITLE := "MARKETER"  , RATING := "SUCKY"); '
+SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 3 , NAME := "TY" , SSNUM := 300 , GENDER := "FEMALE" , BIRTH_DATE := "01/03/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 300300 , HIRE_DATE := "01/03/07" , SALARY := 92000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "AWESOME"); '
+SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 4 , NAME := "PETER" , SSNUM := 400 , GENDER := "FEMALE" , BIRTH_DATE := "01/04/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 400400 , HIRE_DATE := "01/04/07" , SALARY := 112000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "AVERAGE"); '
+SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 5 , NAME := "DERP" , SSNUM := 500 , GENDER := "MALE" , BIRTH_DATE := "01/05/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 500500 , HIRE_DATE := "01/05/07" , SALARY := 85000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "EXCEPTIONAL"); '
+SIM on connOracleNoSQL 'INSERT sim_project_emp (PERSON_ID := 6 , NAME := "BOB" , SSNUM := 600 , GENDER := "MALE" , BIRTH_DATE := "01/06/87" , ADDRESS := "123 NOTHING LN" , CITY := "AUSTIN" , STATE := "TEXAS" , ZIP := 888 , EMP_ID := 600600 , HIRE_DATE := "01/06/07" , SALARY := 187000 , STATUS := "EMPLOYED" , TITLE := "ENGINEER"  , RATING := "SAVANT"); '
 
 # 2 instances of sim_manager
-SIM on connOracleNoSQL 'INSERT sim_manager (PERSON_ID := 7, NAME := "MICHAEL", SSNUM := 700, GENDER := "MALE", BIRTH_DATE := "01/07/87", ADDRESS := "123 NOTHING LN", CITY := "AUSTIN", STATE := "TEXAS", ZIP := 888, EMP_ID := 700700, HIRE_DATE := "01/07/07", SALARY := 147000, STATUS := "EMPLOYED", TITLE := "SUPERVISOR INTERN IN TRAINING" , BONUS := 8423)! '
-SIM on connOracleNoSQL 'INSERT sim_manager (PERSON_ID := 8, NAME := "JOHNSON", SSNUM := 800, GENDER := "FEMALE", BIRTH_DATE := "01/08/87", ADDRESS := "123 NOTHING LN", CITY := "AUSTIN", STATE := "TEXAS", ZIP := 888, EMP_ID := 800800, HIRE_DATE := "01/08/07", SALARY := 187000, STATUS := "EMPLOYED", TITLE := "ASSOCIATE ASSISTANT SUPERVISOR" , BONUS := 5600)! '
+SIM on connOracleNoSQL 'INSERT sim_manager (PERSON_ID := 7, NAME := "MICHAEL", SSNUM := 700, GENDER := "MALE", BIRTH_DATE := "01/07/87", ADDRESS := "123 NOTHING LN", CITY := "AUSTIN", STATE := "TEXAS", ZIP := 888, EMP_ID := 700700, HIRE_DATE := "01/07/07", SALARY := 147000, STATUS := "EMPLOYED", TITLE := "SUPERVISOR INTERN IN TRAINING" , BONUS := 8423); '
+SIM on connOracleNoSQL 'INSERT sim_manager (PERSON_ID := 8, NAME := "JOHNSON", SSNUM := 800, GENDER := "FEMALE", BIRTH_DATE := "01/08/87", ADDRESS := "123 NOTHING LN", CITY := "AUSTIN", STATE := "TEXAS", ZIP := 888, EMP_ID := 800800, HIRE_DATE := "01/08/07", SALARY := 187000, STATUS := "EMPLOYED", TITLE := "ASSOCIATE ASSISTANT SUPERVISOR" , BONUS := 5600); '
 
 # 2 instances of sim_dept, each with a different manager
-SIM on connOracleNoSQL 'INSERT sim_dept (DEPT_ID := 69 , NAME := "ENGINEERING", LOCATION := "AUSTIN")! '
-SIM on connOracleNoSQL 'INSERT sim_dept (DEPT_ID := 10 , NAME := "MARKETING", LOCATION := "NEW YORK")! '
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_manager (department := sim_dept WITH (DEPT_ID = 69)) WHERE EMP_ID = 800800!'
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_manager (department := sim_dept WITH (DEPT_ID = 10)) WHERE EMP_ID = 700700!'
+SIM on connOracleNoSQL 'INSERT sim_dept (DEPT_ID := 69 , NAME := "ENGINEERING", LOCATION := "AUSTIN"); '
+SIM on connOracleNoSQL 'INSERT sim_dept (DEPT_ID := 10 , NAME := "MARKETING", LOCATION := "NEW YORK"); '
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_manager (department := sim_dept WITH (DEPT_ID = 69)) WHERE EMP_ID = 800800;'
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_manager (department := sim_dept WITH (DEPT_ID = 10)) WHERE EMP_ID = 700700;'
 
 # 3 instances of sim_project, 2 in one department and 1 in the other department
-SIM on connOracleNoSQL 'INSERT sim_project (PROJECT_ID := 1234567, NAME := "SUPER SECRET RESEARCH")! '
-SIM on connOracleNoSQL 'INSERT sim_project (PROJECT_ID := 420420, NAME := "DANK PROJECT")! '
-SIM on connOracleNoSQL 'INSERT sim_project (PROJECT_ID := 7654321, NAME := "BORING MARKETING CRAP")! '
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project (department := sim_dept WITH (DEPT_ID = 69)) WHERE PROJECT_ID = 1234567 OR PROJECT_ID = 420420!'
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project (department := sim_dept WITH (DEPT_ID = 10)) WHERE PROJECT_ID = 7654321!'
+SIM on connOracleNoSQL 'INSERT sim_project (PROJECT_ID := 1234567, NAME := "SUPER SECRET RESEARCH"); '
+SIM on connOracleNoSQL 'INSERT sim_project (PROJECT_ID := 420420, NAME := "DANK PROJECT"); '
+SIM on connOracleNoSQL 'INSERT sim_project (PROJECT_ID := 7654321, NAME := "BORING MARKETING CRAP"); '
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project (department := sim_dept WITH (DEPT_ID = 69)) WHERE PROJECT_ID = 1234567 OR PROJECT_ID = 420420;'
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project (department := sim_dept WITH (DEPT_ID = 10)) WHERE PROJECT_ID = 7654321;'
 
 # Assign 2 project employees uniquely to each project
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (projects := sim_project WITH (PROJECT_ID = 1234567)) WHERE EMP_ID = 300300 OR EMP_ID = 500500!'
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (projects := sim_project WITH (PROJECT_ID = 420420)) WHERE EMP_ID = 400400 OR EMP_ID = 600600!'
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (projects := sim_project WITH (PROJECT_ID = 7654321)) WHERE EMP_ID = 100100 OR EMP_ID = 200200!'
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (projects := sim_project WITH (PROJECT_ID = 1234567)) WHERE EMP_ID = 300300 OR EMP_ID = 500500;'
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (projects := sim_project WITH (PROJECT_ID = 420420)) WHERE EMP_ID = 400400 OR EMP_ID = 600600;'
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (projects := sim_project WITH (PROJECT_ID = 7654321)) WHERE EMP_ID = 100100 OR EMP_ID = 200200;'
 
 # Assign employees to their departments, starting with engineering
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (department := sim_dept WITH (DEPT_ID = 69)) WHERE PERSON_ID = 3 OR PERSON_ID = 4 OR PERSON_ID = 5 OR PERSON_ID = 6!'
-SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (department := sim_dept WITH (DEPT_ID = 10)) WHERE PERSON_ID = 1 OR PERSON_ID = 2!'
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (department := sim_dept WITH (DEPT_ID = 69)) WHERE PERSON_ID = 3 OR PERSON_ID = 4 OR PERSON_ID = 5 OR PERSON_ID = 6;'
+SIM on connOracleNoSQL 'MODIFY LIMIT = ALL sim_project_emp (department := sim_dept WITH (DEPT_ID = 10)) WHERE PERSON_ID = 1 OR PERSON_ID = 2;'
 
 
-print "Beginning to query the native SIM database!"
+print "Beginning to query the native SIM database;"
 # 1. Show all instances of the SIM_person class
-SIM on connOracleNoSQL 'from sim_person retrieve *!'
+SIM on connOracleNoSQL 'from sim_person retrieve *;'
 # 2. Show all instances of the SIM_emp class
-SIM on connOracleNoSQL 'from sim_project_emp retrieve *!'
+SIM on connOracleNoSQL 'from sim_project_emp retrieve *;'
 # 3. Show all instances of the SIM_project_emp class along with their respective department name and project name(s).
-SIM on connOracleNoSQL 'from sim_project_emp retrieve *, name OF department, name OF projects!'
+SIM on connOracleNoSQL 'from sim_project_emp retrieve *, name OF department, name OF projects;'
 # 4. Show all instances of the SIM_manager class along with their respective department names
-SIM on connOracleNoSQL 'from sim_manager retrieve *, name OF department!'
+SIM on connOracleNoSQL 'from sim_manager retrieve *, name OF department;'
 # 5. Show all instances of the SIM_project class along with their respective project employee and department name(s).
-SIM on connOracleNoSQL 'from sim_project retrieve *, name OF employees, name OF department!'
+SIM on connOracleNoSQL 'from sim_project retrieve *, name OF employees, name OF department;'
 # 6. Show all instances of the SIM_dept class along with their respective project employee, project, and manager name(s).
-SIM on connOracleNoSQL 'from sim_dept retrieve *, name OF employees, name OF projects, name OF manager!'
+SIM on connOracleNoSQL 'from sim_dept retrieve *, name OF employees, name OF projects, name OF manager;'
 
 
 

--- a/jyhton/src/org/python/ReL/OracleNoSQLDatabase.java
+++ b/jyhton/src/org/python/ReL/OracleNoSQLDatabase.java
@@ -296,7 +296,8 @@ public class OracleNoSQLDatabase extends DatabaseInterface {
     public void ultimateCleanUp(String reason) {
         disconnectFromStore();
         // Explicitly run stop if server is running
-        kvStoreCommand("stop", "-root", storeRoot.getAbsolutePath());
+        if (storeRoot != null)
+            kvStoreCommand("stop", "-root", storeRoot.getAbsolutePath());
 
         // Below may not be needed if above works quickly
         if (storeProcess != null)

--- a/jyhton/src/org/python/ReL/ProcessLanguages.java
+++ b/jyhton/src/org/python/ReL/ProcessLanguages.java
@@ -211,18 +211,21 @@ public class ProcessLanguages {
 
 	public synchronized void processNativeSIM(String ReLstmt) throws Exception {
 
-
 		boolean DBG = true;
-		OracleNoSQLDatabase db = (OracleNoSQLDatabase) connDatabase;
-		if (ReLstmt.equalsIgnoreCase("clear database")) {
-			db.clearDatabase();
-			return;
+		ReLstmt = ReLstmt.replaceAll("\\_\\^\\_", ";");
+
+		if (DBG) {
+			if (ReLstmt.equalsIgnoreCase("clear database")) {
+                OracleNoSQLDatabase db = (OracleNoSQLDatabase) connDatabase;
+                db.clearDatabase();
+                return;
+			}
+			if (ReLstmt.equalsIgnoreCase("stop database")) {
+				OracleNoSQLDatabase db = (OracleNoSQLDatabase) connDatabase;
+				db.ultimateCleanUp("Cleaning up from test.");
+				return;
+			}
 		}
-		if (ReLstmt.equalsIgnoreCase("stop database")) {
-			db.ultimateCleanUp("Stop database");
-			return;
-		}
-		ReLstmt = ReLstmt.replaceAll("!", ";");
 		InputStream is = new ByteArrayInputStream(ReLstmt.getBytes());
 		Query q = null;
 		if( ! parserInitialized) {

--- a/jyhton/src/org/python/ReL/PyRelClassDef.java
+++ b/jyhton/src/org/python/ReL/PyRelClassDef.java
@@ -89,7 +89,7 @@ public class PyRelClassDef {
                 SPARQLDoer.insertObjectPropQuad(connection, baseType.getName(), "rdfs:subClassOf",
                                        type.getName());
             } catch (SQLException e) {
-                System.err.println("OracleNoSQLDatabase error");
+                System.err.println("Database error");
                 e.printStackTrace();
             }
             insertType(baseType); 

--- a/jyhton/src/org/python/ReL/SIMHelper.java
+++ b/jyhton/src/org/python/ReL/SIMHelper.java
@@ -35,7 +35,7 @@ public class SIMHelper {
      * Note:  The connection should not be closed within this class, as it will be closed
      * by its parent (invoker).
      *
-     * @param connection
+     * @param conn
      */
     public SIMHelper(PyRelConnection conn) {
         connection = conn; 
@@ -219,7 +219,7 @@ public class SIMHelper {
 
             }
         } catch (Exception e) {
-            System.out.println("OracleNoSQLDatabase error ");
+            System.out.println("Database error ");
         }
     }
     /*
@@ -231,7 +231,7 @@ public class SIMHelper {
         try {
             SPARQLDoer.insertObjectPropQuad(connection, instanceName.toUpperCase().trim(), "rdf:type", className.trim());
         } catch (Exception e) {
-            System.out.println("OracleNoSQLDatabase error");
+            System.out.println("Database error");
         }
     }
     /*

--- a/jyhton/src/org/python/core/PyBeanEventProperty.java
+++ b/jyhton/src/org/python/core/PyBeanEventProperty.java
@@ -144,7 +144,7 @@ public class PyBeanEventProperty extends PyObject {
     }
 
     private synchronized static Class<?> getAdapterClass(Class<?> c) {
-        String name = "org.python.proxies." + c.getName() + "$OracleNoSQLAdapter";
+        String name = "org.python.proxies." + c.getName() + "$Adapter";
         Class<?> pc = Py.findClass(name);
         if (pc == null) {
             pc = adapterClasses.get(name);


### PR DESCRIPTION
Cleaned up the `processSIMnative` method to work properly with zero knowledge of the type of database it is operating on via the adapter. Fixed the grammar so that SIM statements are now "plug-n-play"!